### PR TITLE
Setup pre-commit hooks w/ black & flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 21.5b1
+    hooks:
+    - id: black
+      language_version: python3
+-   repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+    - id: flake8

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Cassandra
 
-Cassandra is a package for performing factor analysis for sparse datasets. Designed for metagenomics data, it can also be used in other types of datasets including single-cell, or any other sparse dataset. 
+ <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+
+Cassandra is a package for performing factor analysis for sparse datasets. Designed for metagenomics data, it can also be used in other types of datasets including single-cell, or any other sparse dataset.
 
 Machine Learning algorithms usually acts like a black-box, thus what is happening in prediction using an ML algorithm is difficult to know. Cassandra (Greek Mythology: Trojan Priestess of Apollo known for her prophecies) is a tool to envisage potential microbial factors influencing the ML tool based on features. Many times we find the top abundant microbes are not the indicator species. Hence, using Random Forest, we try to determine the indicator species responsible as a differential factors across environments.
 
 Following preprocessing can be done:
+
 - raw: no changes/preprocessing needed in input data
 - total-sum: samples expressed as the probabilities;
 - standard scalar: forces the column to have a mean of 0;
@@ -13,7 +16,8 @@ Following preprocessing can be done:
 ## Installation
 
 From source
-```
+
+```bash
 git clone https://github.com/Chandrima-04/Cassandra.git
 cd Cassandra
 python setup.py install
@@ -21,6 +25,6 @@ python setup.py install
 
 ## Usage
 
-```
+```bash
 cassandra predict --feature-name <Metadata-factor> ...  <input> <meta-data> <output>
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cassandra
-
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
  <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 
 Cassandra is a package for performing factor analysis for sparse datasets. Designed for metagenomics data, it can also be used in other types of datasets including single-cell, or any other sparse dataset.

--- a/cassandra/cli.py
+++ b/cassandra/cli.py
@@ -10,52 +10,82 @@ from .preprocessing import (
     normalize_data,
 )
 
-from .prediction import (
-    prediction_methodology
-)
+from .prediction import prediction_methodology
+
 
 @click.group()
 def main():
     pass
 
 
-@main.command('predict')
-@click.option('--feature-name', default='Location',
-               help='The feature to predict on')
-@click.option('--accuracy', default=0.75,
-               help='Desired accuracy for the model')
-@click.option('--test-size', default=0.2,
-              help='The relative size of the test data')
-@click.option('--num-estimators', default=20,
-              help='Number of trees in our random forest')
-@click.option('--num-runs', default=100, help='Number of random forest runs')
-@click.option('--num-data', default=50,
-              help='Number of top data variables to be predicted')
-@click.option('--normalize-method', default='standard_scalar',
-              help='Normalization method to be used')
-@click.option('--normalize-threshold', default='0.0001',
-              help='Normalization threshold for binary normalization.')
-@click.argument('data-file', type=click.File('r'))
-@click.argument('metadata-file', type=click.File('r'))
-@click.argument('out-dir')
-def predict_top_features(feature_name, accuracy, test_size, num_estimators, num_runs,
-                         num_data, normalize_method, normalize_threshold,
-                         data_file, metadata_file, out_dir):
+@main.command("predict")
+@click.option("--feature-name", default="Location", help="The feature to predict on")
+@click.option("--accuracy", default=0.75, help="Desired accuracy for the model")
+@click.option("--test-size", default=0.2, help="The relative size of the test data")
+@click.option(
+    "--num-estimators", default=20, help="Number of trees in our random forest"
+)
+@click.option("--num-runs", default=100, help="Number of random forest runs")
+@click.option(
+    "--num-data", default=50, help="Number of top data variables to be predicted"
+)
+@click.option(
+    "--normalize-method",
+    default="standard_scalar",
+    help="Normalization method to be used",
+)
+@click.option(
+    "--normalize-threshold",
+    default="0.0001",
+    help="Normalization threshold for binary normalization.",
+)
+@click.argument("data-file", type=click.File("r"))
+@click.argument("metadata-file", type=click.File("r"))
+@click.argument("out-dir")
+def predict_top_features(
+    feature_name,
+    accuracy,
+    test_size,
+    num_estimators,
+    num_runs,
+    num_data,
+    normalize_method,
+    normalize_threshold,
+    data_file,
+    metadata_file,
+    out_dir,
+):
     """Train a random-forest model to predict the top data variables."""
     raw_data, microbes = parse_raw_data(data_file)
     seed = randint(0, 500)
-    feature, name_map = parse_feature(metadata_file, raw_data.index, feature_name=feature_name)
-    new_index = feature!= -1
+    feature, name_map = parse_feature(
+        metadata_file, raw_data.index, feature_name=feature_name
+    )
+    new_index = feature != -1
     raw_data = raw_data[new_index == True]
     feature = feature[new_index == True]
-    normalized = normalize_data(raw_data, method=normalize_method, threshold=normalize_threshold)
-    print ("Shape of dataset after normalization", normalized.shape)
+    normalized = normalize_data(
+        raw_data, method=normalize_method, threshold=normalize_threshold
+    )
+    print("Shape of dataset after normalization", normalized.shape)
     top_features_rf, model_parameters_rf = prediction_methodology(
-                                     normalized, feature,
-                                     microbes, accuracy=accuracy, num_runs=num_runs, num_data=num_data,
-                                     test_size=test_size, num_estimators=num_estimators, seed=seed)
-    top_features_rf.to_csv(os.path.join(out_dir, str('top_data_feature_rf_' + normalize_method + '.csv')))
-    model_parameters_rf.to_csv(os.path.join(out_dir, str('model_parameters_rf_' + normalize_method + '.csv')))
+        normalized,
+        feature,
+        microbes,
+        accuracy=accuracy,
+        num_runs=num_runs,
+        num_data=num_data,
+        test_size=test_size,
+        num_estimators=num_estimators,
+        seed=seed,
+    )
+    top_features_rf.to_csv(
+        os.path.join(out_dir, str("top_data_feature_rf_" + normalize_method + ".csv"))
+    )
+    model_parameters_rf.to_csv(
+        os.path.join(out_dir, str("model_parameters_rf_" + normalize_method + ".csv"))
+    )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/cassandra/cli.py
+++ b/cassandra/cli.py
@@ -1,16 +1,12 @@
-import pandas as pd
-import numpy as np
 import os.path
-import click
 from random import randint
 
-from .preprocessing import (
-    parse_raw_data,
-    parse_feature,
-    normalize_data,
-)
+import click
+import numpy as np
+import pandas as pd
 
 from .prediction import prediction_methodology
+from .preprocessing import normalize_data, parse_feature, parse_raw_data
 
 
 @click.group()

--- a/cassandra/prediction.py
+++ b/cassandra/prediction.py
@@ -11,9 +11,11 @@ from sklearn.metrics import (
     accuracy_score,
 )
 
+
 def split_data(data_tbl, features, test_size=0.2, seed=None):
     """Return a tuple of length four with train data, test data, train feature, test feature."""
     return train_test_split(data_tbl, features, test_size=test_size, random_state=seed)
+
 
 def train_random_forest(data_tbl, features, n_estimators=20, seed=None):
     """Return a trained random forest model to predict features from data."""
@@ -21,52 +23,79 @@ def train_random_forest(data_tbl, features, n_estimators=20, seed=None):
     classifier.fit(data_tbl, features)
     return classifier
 
+
 def predict_with_model(model, data_tbl):
     """Return a dictionary with evaluation data for the model on the data."""
     return model.predict(data_tbl)
 
+
 def feature_importance(microbes, model):
     """Return the top features of importance as selected by Random Forest Classifier."""
     importances = model.feature_importances_
-    #feature_val = sorted(zip(microbes, importances), key=lambda x: x[1], reverse=True)
+    # feature_val = sorted(zip(microbes, importances), key=lambda x: x[1], reverse=True)
     feature_val = zip(microbes, importances)
     return feature_val
 
 
-def prediction_methodology(normalized, feature, microbes, accuracy, num_runs,
-                           num_data, test_size, num_estimators, seed):
+def prediction_methodology(
+    normalized,
+    feature,
+    microbes,
+    accuracy,
+    num_runs,
+    num_data,
+    test_size,
+    num_estimators,
+    seed,
+):
     """Code to integrate prediction of features with model accuracy"""
     train_data, test_data, train_feature, test_feature = split_data(
         normalized, feature, test_size=test_size, seed=seed
     )
     col_names = [
-        'Accuracy',
-        'Precision',
-        'Recall',
+        "Accuracy",
+        "Precision",
+        "Recall",
     ]
-    i,j = 0,0
-    model_results = pd.DataFrame(columns = col_names)
-    feature_dataframe = pd.DataFrame(columns = microbes)
+    i, j = 0, 0
+    model_results = pd.DataFrame(columns=col_names)
+    feature_dataframe = pd.DataFrame(columns=microbes)
     flag = 0
-    while (i < num_runs):
-        j+=1
+    while i < num_runs:
+        j += 1
         model = train_random_forest(
-                train_data, train_feature, n_estimators=num_estimators
-    	        )
+            train_data, train_feature, n_estimators=num_estimators
+        )
         predictions = predict_with_model(model, test_data).round()
-        if accuracy_score(test_feature, predictions.round())>=accuracy :
+        if accuracy_score(test_feature, predictions.round()) >= accuracy:
             i += 1
             flag = 1
-            model_results = model_results.append({'Accuracy':accuracy_score(test_feature, predictions.round()),
-                        'Precision':precision_score(test_feature, predictions, average='weighted'),
-                        'Recall':recall_score(test_feature, predictions, average='weighted')
-                        }, ignore_index = True)
-        elif j>=15000 and flag==0:
+            model_results = model_results.append(
+                {
+                    "Accuracy": accuracy_score(test_feature, predictions.round()),
+                    "Precision": precision_score(
+                        test_feature, predictions, average="weighted"
+                    ),
+                    "Recall": recall_score(
+                        test_feature, predictions, average="weighted"
+                    ),
+                },
+                ignore_index=True,
+            )
+        elif j >= 15000 and flag == 0:
             i += 1
-            model_results = model_results.append({'Accuracy':accuracy_score(test_feature, predictions.round()),
-                        'Precision':precision_score(test_feature, predictions, average='weighted'),
-                        'Recall':recall_score(test_feature, predictions, average='weighted')
-                        }, ignore_index = True)
+            model_results = model_results.append(
+                {
+                    "Accuracy": accuracy_score(test_feature, predictions.round()),
+                    "Precision": precision_score(
+                        test_feature, predictions, average="weighted"
+                    ),
+                    "Recall": recall_score(
+                        test_feature, predictions, average="weighted"
+                    ),
+                },
+                ignore_index=True,
+            )
         feature_list = feature_importance(microbes, model)
         for microbes_name, values in feature_list:
             feature_dataframe.loc[i, microbes_name] = values

--- a/cassandra/prediction.py
+++ b/cassandra/prediction.py
@@ -1,15 +1,10 @@
 import numpy as np
 import pandas as pd
-from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import (
-    precision_score,
-    recall_score,
-    confusion_matrix,
-    classification_report,
-    accuracy_score,
-)
+from sklearn.metrics import (accuracy_score, classification_report,
+                             confusion_matrix, precision_score, recall_score)
+from sklearn.model_selection import train_test_split
 
 
 def split_data(data_tbl, features, test_size=0.2, seed=None):

--- a/cassandra/prediction.py
+++ b/cassandra/prediction.py
@@ -1,9 +1,7 @@
 import numpy as np
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import (accuracy_score, classification_report,
-                             confusion_matrix, precision_score, recall_score)
+from sklearn.metrics import accuracy_score, precision_score, recall_score
 from sklearn.model_selection import train_test_split
 
 

--- a/cassandra/preprocessing.py
+++ b/cassandra/preprocessing.py
@@ -15,7 +15,7 @@ def parse_raw_data(filename):
     return new_tbl, header
 
 
-def parse_feature(metadata_filename, sample_names, feature_name='city'):
+def parse_feature(metadata_filename, sample_names, feature_name="city"):
     """Return a tuple of factorized features for our samples and a map
     from factor values to feature names.
     """
@@ -25,26 +25,30 @@ def parse_feature(metadata_filename, sample_names, feature_name='city'):
     factorized, name_map = pd.factorize(feature)
     return factorized, name_map
 
-def normalize_data(data_tbl, method='standard_scalar',threshold=0.0001):
+
+def normalize_data(data_tbl, method="standard_scalar", threshold=0.0001):
     """Return a pandas dataframe ready for classification.
     Normalize/preprocess the dataset according to the
     specified method.
     """
     processor = {
-        'standard_scalar': normalize_data_standard_scalar,
-        'total_sum' : normalize_data_total_sum,
-        'binary' : normalize_data_binary,
+        "standard_scalar": normalize_data_standard_scalar,
+        "total_sum": normalize_data_total_sum,
+        "binary": normalize_data_binary,
     }[method.lower()]
     return processor(data_tbl)
+
 
 def normalize_data_standard_scalar(data_tbl):
     """Return a data table with each column standardized to have a mean of 0."""
     sc = StandardScaler()
     return sc.fit_transform(data_tbl)
 
+
 def normalize_data_total_sum(data_tbl):
     """Return a data table with each value divided by its row sum."""
-    return ((data_tbl.T / data_tbl.T.sum()).T)
+    return (data_tbl.T / data_tbl.T.sum()).T
+
 
 def normalize_data_binary(data_tbl, threshold=0.0001):
     """Return a data table with 1 and 0 based on a threshold"""

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 import setuptools
 
 requirements = [
-    'scikit-learn',
-    'numpy',
-    'pandas',
-    'scipy',
-    'click',
+    "scikit-learn",
+    "numpy",
+    "pandas",
+    "scipy",
+    "click",
 ]
 
 
@@ -17,10 +17,10 @@ setuptools.setup(
     author_email="cb4603@nyu.edu",
     description="Predict top contributors for sample distinction",
     packages=setuptools.find_packages(),
-    package_dir={'cassandra': 'cassandra'},
+    package_dir={"cassandra": "cassandra"},
     entry_points={
-        'console_scripts': [
-            'cassandra=cassandra.cli:main',
+        "console_scripts": [
+            "cassandra=cassandra.cli:main",
         ]
     },
     install_requires=requirements,


### PR DESCRIPTION
This PR adds a pre-commit hook to configure automated formatting and linting using black & flake8 on committing. 
- Flake8: ensures code follows the standard python conventions as defined in [PEP8](https://www.python.org/dev/peps/pep-0008/)
- Isort: sort imports alphabetically & automatically separate into sections by type
- Black: Auto-formatter to keep code need, readable and consistent 
- Added badges for code style & license to README

To install the hooks, run `pre-commit install` (one-time dev setup)
If you ever need to skip these hooks, you can run `git commit --no-verify` and proceed as done before.

All changes in this PR are purely cosmetic and do not alter existing core functionality.